### PR TITLE
Add docker-machine package to instruction

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,9 @@ git reset --hard HEAD
 Before attempting to build openlibrary using the docker instructions below, please follow this checklist. If you encounter an error, this section may serve as a troubleshooting guide:
 
 - These instructions require `docker-ce 18.*` 
-- You will need to first install `docker-compose`
+- You will need to first install `docker-compose` and `docker-machine`
+- Make sure you have a docker-machine with name 'default' else checkout [this](https://docs.docker.com/machine/reference/create/)
+- Make sure docker is [managed as a non root user](https://docs.docker.com/install/linux/linux-postinstall/) or add sudo before commands below to execute
 - Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`
 
 ### For All Users


### PR DESCRIPTION
Added docker-machine package and making sure that docker is added as a non root user

> **Description**: Installation instruction updated
 - added docker-machine related instruction and related links
 - Mentioned to add `sudo` before commands to execute or manage docker as a non root user(Related links added)

Closes #1991